### PR TITLE
Addon should not depend in ember-cli-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ember-ajax": "0.7.1",
     "ember-cli": "2.4.3",
     "ember-cli-app-version": "^1.0.0",
+    "ember-cli-babel": "^5.1.6",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
@@ -44,7 +45,6 @@
   "dependencies": {
     "broccoli-filter": "^1.2.3",
     "broccoli-merge-trees": "^1.1.1",
-    "ember-cli-babel": "^5.1.6",
     "rtlcss": "^2.0.3"
   },
   "ember-addon": {


### PR DESCRIPTION
Only addons that ship runtime code should have ember-cli-babel as a runtime dependency

@dbouwman could you release a new version of the addon after this?